### PR TITLE
sets flags to disable telemetry

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -10,6 +10,15 @@ RUN npm ci --omit=dev --ignore-scripts
 
 COPY . .
 
+# Keystone telemetry flag
+ENV KEYSTONE_TELEMETRY_DISABLED=1
+
+# Prisma telemetry flag
+ENV CHECKPOINT_DISABLE=1
+
+# NextJS telemetry flag
+ENV NEXT_TELEMETRY_DISABLED=1
+
 ARG SESSION_SECRET
 
 # Allow scripts, keystone uses that to generate files


### PR DESCRIPTION
Keystone, NextJS, and Prisma all have telemetry enabled by default, so we need to disable for the Merch Store.

**Opt out for Keystone**
https://keystonejs.com/docs/reference/telemetry#how-to-opt-out

**Opt out for NextJS**
https://nextjs.org/telemetry#how-do-i-opt-out

**Opt out for Prisma**
https://www.prisma.io/docs/concepts/more/telemetry#how-to-opt-out-of-data-collection