### PR TITLE
fix(dockerfile): Restore default pnpm store-dir path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,6 @@ RUN mkdir -p /pnpm && chown -R node:node /app /pnpm
 
 USER node
 
-# Use a short store path to keep tsx IPC socket paths under the 108-byte Unix domain socket limit.
-#
-# Git-hosted deps run prepare scripts via tsx, which creates a named pipe inside
-# the pnpm store tmp dir that results in EINVAL on listen().
-#
-# Default dir: /root/.local/share/pnpm/store/v11/tmp/node_modules/.tmp/tsx-<id>/<pid>.pipe (>108 characters)
-# Modified dir: /pnpm/v11/tmp/node_modules/.tmp/tsx-<id>/<pid>.pipe (<90 characters)
-RUN pnpm config set store-dir /pnpm
-
 COPY --chown=node:node ["package.json", "pnpm-workspace.yaml", "pnpm-lock.yaml", "./"]
 RUN pnpm ci --prod --ignore-scripts
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
+# Injected by GitHub Actions; for local builds, use '--build-arg NODE_VERSION=$(cat .node-version)'
 ARG NODE_VERSION
+
 FROM public.ecr.aws/docker/library/node:${NODE_VERSION}
 
 RUN corepack enable
@@ -9,11 +11,13 @@ RUN mkdir -p /pnpm && chown -R node:node /app /pnpm
 USER node
 
 COPY --chown=node:node ["package.json", "pnpm-workspace.yaml", "pnpm-lock.yaml", "./"]
+
+# Injected by GitHub Actions (fallback for local builds, gets overridden by an explicit '--build-arg')
+ARG PUBLIC_ASSETS_PATH=""
+
 RUN pnpm ci --prod --ignore-scripts
 
 COPY --chown=node:node . .
-
-ARG PUBLIC_ASSETS_PATH
 
 RUN pnpm rebuild
 RUN pnpm run build


### PR DESCRIPTION
The overly long IPC file path affects `root` user only - see https://github.com/pnpm/pnpm/issues/12222. Since we've switched to `node` recently, let's restore the default pnpm store path.

@AlanBreck the Docker build fails with the following error (`staging` branch is affected too):

```
 => [8/9] RUN pnpm rebuild                                                                                                                                                                       1.4s
 => ERROR [9/9] RUN pnpm run build                                                                                                                                                               0.8s
------
 > [9/9] RUN pnpm run build:
0.358 $ vite build
0.720 error during build:
0.720 [Could not load /app/svelte.config.js: config.kit.csp.directives.img-src must be an array of strings, if specified
0.720 ]
0.736 [ELIFECYCLE] Command failed with exit code 1.
------
```