### PR TITLE
fix(ci): fix build for fe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /pnpm && chown -R node:node /app /pnpm
 
 USER node
 
-COPY --chown=node:node --parents package.json pnpm-workspace.yaml pnpm-lock.yaml scripts/ ./
+COPY --chown=node:node --parents package.json pnpm-workspace.yaml pnpm-lock.yaml scripts/postinstall.js ./
 
 # Injected by GitHub Actions (fallback for local builds, gets overridden by an explicit '--build-arg')
 ARG PUBLIC_ASSETS_PATH=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY --chown=node:node ["package.json", "pnpm-workspace.yaml", "pnpm-lock.yaml",
 ARG PUBLIC_ASSETS_PATH=""
 
 COPY --chown=node:node ./scripts/postinstall.js ./scripts/
-RUN SKIP_POSTINSTALL=1 pnpm ci
+RUN SKIP_POSTINSTALL=1 pnpm ci --prod
 
 COPY --chown=node:node . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,12 @@ COPY --chown=node:node ["package.json", "pnpm-workspace.yaml", "pnpm-lock.yaml",
 # Injected by GitHub Actions (fallback for local builds, gets overridden by an explicit '--build-arg')
 ARG PUBLIC_ASSETS_PATH=""
 
-RUN pnpm ci --prod --ignore-scripts
+COPY --chown=node:node ./scripts/postinstall.js ./scripts/
+RUN SKIP_POSTINSTALL=1 pnpm ci
 
 COPY --chown=node:node . .
 
-RUN pnpm rebuild
+RUN node scripts/postinstall.js
 RUN pnpm run build
 
 CMD [ "pnpm", "run", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,11 @@ RUN mkdir -p /pnpm && chown -R node:node /app /pnpm
 
 USER node
 
-COPY --chown=node:node ["package.json", "pnpm-workspace.yaml", "pnpm-lock.yaml", "./"]
+COPY --chown=node:node --parents package.json pnpm-workspace.yaml pnpm-lock.yaml scripts/ ./
 
 # Injected by GitHub Actions (fallback for local builds, gets overridden by an explicit '--build-arg')
 ARG PUBLIC_ASSETS_PATH=""
 
-COPY --chown=node:node ./scripts/postinstall.js ./scripts/
 RUN SKIP_POSTINSTALL=1 pnpm ci --prod
 
 COPY --chown=node:node . .

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "prettier --check --plugin-search-dir=. .",
     "format": "prettier --write --plugin-search-dir=. .",
     "gen": "graphql-codegen --config codegen.yml",
-    "postinstall": "node scripts/copy-dependencies.js && pnpm gen"
+    "postinstall": "node scripts/postinstall.js"
   },
   "type": "module",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "@stablelib/utf8": "2.1.0",
     "@sveltejs/adapter-node": "5.5.4",
     "@sveltejs/kit": "2.60.1",
+    "@sveltejs/vite-plugin-svelte": "7.1.2",
+    "@tsconfig/svelte": "5.0.8",
     "autoprefixer": "10.5.0",
     "graphql": "16.14.0",
     "graphql-request": "7.4.0",
@@ -50,10 +52,6 @@
     "tweetnacl": "1.0.3",
     "typescript": "5.9.3",
     "vite": "8.0.14"
-  },
-  "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "7.1.2",
-    "@tsconfig/svelte": "5.0.8"
   },
   "engines": {
     "npm": "please-use-pnpm",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,12 @@ importers:
       '@sveltejs/kit':
         specifier: 2.60.1
         version: 2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.9)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.100.0)(yaml@2.9.0)))(svelte@5.55.9)(typescript@5.9.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.100.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte':
+        specifier: 7.1.2
+        version: 7.1.2(svelte@5.55.9)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.100.0)(yaml@2.9.0))
+      '@tsconfig/svelte':
+        specifier: 5.0.8
+        version: 5.0.8
       autoprefixer:
         specifier: 10.5.0
         version: 10.5.0(postcss@8.5.15)
@@ -113,13 +119,6 @@ importers:
       vite:
         specifier: 8.0.14
         version: 8.0.14(@types/node@25.9.1)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.100.0)(yaml@2.9.0)
-    devDependencies:
-      '@sveltejs/vite-plugin-svelte':
-        specifier: 7.1.2
-        version: 7.1.2(svelte@5.55.9)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.100.0)(yaml@2.9.0))
-      '@tsconfig/svelte':
-        specifier: 5.0.8
-        version: 5.0.8
 
 packages:
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process'
 
 if (!process.env.SKIP_POSTINSTALL) {
-  execSync('node scripts/copy-dependencies.js && pnpm gen', { stdio: 'inherit', shell: true })
+  execSync('node scripts/copy-dependencies.js && pnpm gen', { stdio: 'inherit' })
 }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,5 @@
+import { execSync } from 'child_process'
+
+if (!process.env.SKIP_POSTINSTALL) {
+  execSync('node scripts/copy-dependencies.js && pnpm gen', { stdio: 'inherit', shell: true })
+}


### PR DESCRIPTION
Running `pnpm` with `--ignore-scripts` breaks the build since `@brave/leo` never runs the build script. This change adds a flag so that all other dependency scripts (approved via `allowBuilds` in `pnpm-workspace.yaml`) run, but the root `postinstall` script does not during the initial installation phase.